### PR TITLE
Use state for compact info

### DIFF
--- a/assets/js/client.es6.js
+++ b/assets/js/client.es6.js
@@ -15,6 +15,8 @@ ClientReactApp = mixin(ClientReactApp);
 import config from '../../src/config';
 import plugins from '../../src/plugins';
 
+import constants from '../../src/constants';
+
 import routes from '../../src/routes';
 import TweenLite from 'gsap';
 
@@ -33,8 +35,7 @@ function modifyContext (ctx) {
   ctx.token = this.getState('token');
   ctx.user = this.getState('user');
   ctx.useCache = true;
-  var compact = this.getState('compact');
-  ctx.compact = compact === 'true' || compact === true;
+  ctx.compact = this.getState('compact').toString() === 'true';
 
   return ctx;
 }
@@ -144,6 +145,10 @@ function initialize(bindLinks) {
     app.setState('renderTracking', false);
     app.render(app.fullPathName(), true, modifyContext);
     app.config.renderTracking = true;
+
+    app.on(constants.COMPACT_TOGGLE, function(compact) {
+      app.setState('compact', compact);
+    });
   });
 }
 

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -89,7 +89,7 @@ function routes(app) {
       showBetaBanner: ctx.showBetaBanner,
       userAgent: ctx.userAgent,
       csrf: ctx.csrf,
-      compact: ctx.compact,
+      compact: ctx.compact.toString() === 'true',
       query: ctx.query,
       params: ctx.params,
       url: ctx.path,

--- a/src/views/components/Listing.jsx
+++ b/src/views/components/Listing.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import moment from 'moment';
 
+import constants from '../../constants';
+
 import short from '../../lib/formatDifference';
 import mobilify from '../../lib/mobilify';
 
@@ -66,7 +68,8 @@ class Listing extends React.Component {
     super(props);
 
     this.state = {
-      expanded: this.props.expanded,
+      expanded: props.expanded,
+      compact: props.compact,
     };
 
     if (typeof window !== 'undefined') {
@@ -80,10 +83,26 @@ class Listing extends React.Component {
     } else {
       this.state.windowWidth = 800;
     }
+
+    this._onCompactToggle = this._onCompactToggle.bind(this);
   }
 
   shouldComponentUpdate(nextProps, nextState) {
     return (nextProps !== this.props || nextState !== this.state);
+  }
+
+  _onCompactToggle (state) {
+    this.setState({
+      compact: state,
+    });
+  }
+
+  componentDidMount() {
+    this.props.app.on(constants.COMPACT_TOGGLE, this._onCompactToggle);
+  }
+
+  componentWillUnount() {
+    this.props.app.off(constants.COMPACT_TOGGLE, this._onCompactToggle);
   }
 
   buildImage(data) {
@@ -95,8 +114,7 @@ class Listing extends React.Component {
       httpsProxy: ctx.props.httpsProxy,
     });
 
-    var compact = this.props.compact || false;
-    compact = compact === 'true' || compact === true;
+    var compact = this.state.compact;
 
     if (expanded) {
       if (html5) {
@@ -170,7 +188,7 @@ class Listing extends React.Component {
 
   buildOver18() {
     return (
-      <a className={'listing-preview-a listing-nsfw' + (this.props.compact ? ' compact' : '')} href={ this.props.listing.permalink } onClick={ this.expand.bind(this) } data-no-route='true'>
+      <a className={'listing-preview-a listing-nsfw' + (this.state.compact ? ' compact' : '')} href={ this.props.listing.permalink } onClick={ this.expand.bind(this) } data-no-route='true'>
         <span className={'icon-nsfw-circled'}/>
       </a>
     );
@@ -243,8 +261,7 @@ class Listing extends React.Component {
     var preview = this.previewImageUrl(listing, expanded);
 
 
-    var compact = this.props.compact || false;
-    compact = compact === 'true' || compact === true;
+    var compact = this.state.compact;
 
     if (this.isNSFW(listing) && !this.state.expanded) {
       return this.buildOver18();
@@ -384,7 +401,7 @@ class Listing extends React.Component {
   }
 
   expand(e) {
-    if(!this.props.compact) {
+    if(!this.state.compact) {
       if (e.target && e.target.tagName === 'A' && e.target.href) {
         return true;
       } else {
@@ -437,9 +454,7 @@ class Listing extends React.Component {
     var when;
 
     var expanded = this.state.expanded || this.props.single;
-
-    var compact = this.props.compact || false;
-    compact = compact === 'true' || compact === true;
+    var compact = this.state.compact;
 
     if (!props.hideSubredditLabel) {
       subredditLabel = (

--- a/src/views/components/SideNav.jsx
+++ b/src/views/components/SideNav.jsx
@@ -8,6 +8,7 @@ class SideNav extends React.Component {
     this.state = {
       opened: false,
       twirly: '',
+      compact: props.compact,
     };
 
     this._onTwirlyClick = this._onTwirlyClick.bind(this);
@@ -30,6 +31,7 @@ class SideNav extends React.Component {
     var user = this.props.user;
     var loginLink;
     var logoutLink;
+    var compact = this.state.compact;
 
     if (user) {
       loginLink = (
@@ -50,9 +52,6 @@ class SideNav extends React.Component {
         </li>
       );
     }
-    var state = this.props.app.state;
-    var compact = state ? state.compact : false;
-    compact = compact === 'true' || compact === true;
 
     return (
       <nav className={'SideNav tween' + (this.state.opened?' opened':'')}>
@@ -65,7 +64,7 @@ class SideNav extends React.Component {
           { logoutLink }
 
           <li>
-            <button className='SideNav-button' onClick={this._onViewClick}>Switch to {compact ? 'list' : 'compact'} view</button>
+            <button className='SideNav-button' onClick={this._onViewClick}>Switch to { compact ? 'list' : 'compact' } view</button>
           </li>
           <li className={'SideNav-dropdown tween'+(this.state.twirly === 'about' ? ' opened' : '')}>
             <button className={'twirly before SideNav-button'+(this.state.twirly === 'about' ? ' opened' : '')} onClick={this._onTwirlyClick.bind(this, 'about')}>About</button>
@@ -146,11 +145,16 @@ class SideNav extends React.Component {
 
   _onViewClick() {
     var app = this.props.app;
-    var compact = app.state.compact === 'true' || app.state.compact === true;
+
+    var compact = this.state.compact;
     document.cookie = 'compact=' + (!compact) + '; expires=Fri, 31 Dec 2020 23:59:59 GMT';
-    app.setState('compact', !compact);
+
     app.emit(constants.COMPACT_TOGGLE, !compact);
     this._close();
+
+    this.setState({
+      compact: !compact,
+    });
   }
 }
 

--- a/src/views/layouts/BodyLayout.jsx
+++ b/src/views/layouts/BodyLayout.jsx
@@ -11,7 +11,6 @@ var BetaBanner;
 class BodyLayout extends React.Component {
   constructor(props) {
     super(props);
-    this._onCompactToggle = this._onCompactToggle.bind(this);
   }
 
   render () {
@@ -25,18 +24,6 @@ class BodyLayout extends React.Component {
         </main>
       </div>
     );
-  }
-
-  componentDidMount() {
-    this.props.app.on(constants.COMPACT_TOGGLE, this._onCompactToggle);
-  }
-
-  componentWillUnount() {
-    this.props.app.off(constants.COMPACT_TOGGLE, this._onCompactToggle);
-  }
-
-  _onCompactToggle() {
-    this.forceUpdate();
   }
 }
 

--- a/src/views/pages/index.jsx
+++ b/src/views/pages/index.jsx
@@ -30,9 +30,11 @@ class IndexPage extends React.Component {
     this.state = {
       data: props.data || {},
       subredditName: subredditName,
+      compact: props.compact,
     };
 
     this.state.loaded = this.state.data && this.state.data.data;
+    this._onCompactToggle = this._onCompactToggle.bind(this);
   }
 
   componentDidMount() {
@@ -45,6 +47,17 @@ class IndexPage extends React.Component {
     }).bind(this));
 
     this.props.app.emit(constants.TOP_NAV_SUBREDDIT_CHANGE, this.state.subredditName);
+    this.props.app.on(constants.COMPACT_TOGGLE, this._onCompactToggle);
+  }
+
+  _onCompactToggle (state) {
+    this.setState({
+      compact: state,
+    });
+  }
+
+  componentWillUnount() {
+    this.props.app.off(constants.COMPACT_TOGGLE, this._onCompactToggle);
   }
 
   componentDidUpdate() {
@@ -55,6 +68,8 @@ class IndexPage extends React.Component {
     var loading;
     var props = this.props;
     var data = this.state.data;
+
+    var compact = this.state.compact;
 
     if (!this.state.loaded) {
       return (
@@ -132,7 +147,7 @@ class IndexPage extends React.Component {
     if (this.state.data.meta && props.renderTracking) {
       tracking = (<TrackingPixel url={ this.state.data.meta.tracking } user={ props.user } loid={ props.loid } loidcreated={ props.loidcreated } />);
     }
-    var compact = app.state ? app.state.compact : false;
+
     return (
       <div>
         { loading }

--- a/src/views/pages/search.jsx
+++ b/src/views/pages/search.jsx
@@ -31,6 +31,7 @@ class SearchPage extends React.Component {
       data: props.data || {},
       subreddits: props.subreddits || {},
       loaded: !!(props.data && props.data.data),
+      compact: props.compact,
     };
   }
 
@@ -126,8 +127,10 @@ class SearchPage extends React.Component {
   render() {
     var state = this.state;
     var props = this.props;
+
     var app = props.app;
     var apiOptions = props.apiOptions;
+    var compact = state.compact;
 
     var controls;
     var tracking;
@@ -225,7 +228,7 @@ class SearchPage extends React.Component {
                     user={ props.user }
                     token={ props.token }
                     api={ props.api }
-                    compact={app.state.compact}
+                    compact={ compact }
                   />
                 );
               }

--- a/src/views/pages/userActivity.jsx
+++ b/src/views/pages/userActivity.jsx
@@ -24,9 +24,11 @@ class UserActivityPage extends React.Component {
 
     this.state = {
       data: props.data || {},
+      compact: props.compact,
     };
 
     this.state.loaded = this.state.data && this.state.data.data;
+    this._onCompactToggle = this._onCompactToggle.bind(this);
   }
 
   componentDidMount() {
@@ -38,17 +40,29 @@ class UserActivityPage extends React.Component {
     }).bind(this));
 
     this.props.app.emit(constants.TOP_NAV_SUBREDDIT_CHANGE, 'u/' + this.props.userName);
+    this.props.app.on(constants.COMPACT_TOGGLE, this._onCompactToggle);
   }
 
   componentDidUpdate() {
     this.props.app.emit('page:update', this.props);
   }
 
+  _onCompactToggle (state) {
+    this.setState({
+      compact: state,
+    });
+  }
+
+  componentWillUnount() {
+    this.props.app.off(constants.COMPACT_TOGGLE, this._onCompactToggle);
+  }
+
   render() {
     var loading;
     var props = this.props;
+    var state = this.state;
 
-    if (!this.state.loaded) {
+    if (!state.loaded) {
       loading = (
         <Loading />
       );
@@ -58,10 +72,12 @@ class UserActivityPage extends React.Component {
     var api = props.api;
     var token = props.token;
 
+    var compact = state.compact;
+
     var app = props.app;
     var user = props.user;
 
-    var activities = this.state.data.data || [];
+    var activities = state.data.data || [];
 
     var subreddit = '';
 
@@ -73,8 +89,8 @@ class UserActivityPage extends React.Component {
     var tracking;
     var loginPath = props.loginPath;
 
-    if (this.state.data.meta && props.renderTracking) {
-      tracking = (<TrackingPixel url={ this.state.data.meta.tracking } user={ props.user } loid={ props.loid } loidcreated={ props.loidcreated } />);
+    if (state.data.meta && props.renderTracking) {
+      tracking = (<TrackingPixel url={ state.data.meta.tracking } user={ props.user } loid={ props.loid } loidcreated={ props.loidcreated } />);
     }
 
     return (
@@ -84,7 +100,7 @@ class UserActivityPage extends React.Component {
 
         { loading }
 
-        <div className={'container listing-container' + (app.state.compact ? ' compact' : '')} >
+        <div className={'container listing-container' + ( compact ? ' compact' : '' )} >
           {
             activities.map(function(thing, i) {
               var index = (page * 25) + i;
@@ -105,7 +121,7 @@ class UserActivityPage extends React.Component {
                     api={api}
                     hideUser={ true }
                     loginPath={ loginPath }
-                    compact={app.state.compact}
+                    compact={ compact }
                   />
                 );
               } else if (thing._type === 'Comment') {


### PR DESCRIPTION
This changes everything to use component state instead of calling out to app state for `compact` info; there were inconsistencies before, such as the server rendering list view and then the client overwriting to compact view.

It may make sense to eventually expose the cookies to app getState, and then both server and client can just use the state functions, but I need to review security implications first.